### PR TITLE
updated the Gentoo kernel CI buildbot url

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -183,7 +183,7 @@ c['titleURL'] = "https://wiki.gentoo.org/wiki/Project:Kernel"
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
 
-c['buildbotURL'] = "http://192.168.122.2:8010/"
+c['buildbotURL'] = "http://http://kernel1.amd64.dev.gentoo.org:8010/"
 
 # minimalistic config to activate new web UI
 c['www'] = dict(port=8010,


### PR DESCRIPTION
Gentoo Kernel CI as been public released, so we are updating the url